### PR TITLE
Add libgmp detection and automatic linking.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,8 +126,6 @@ if test "x$CONFIG_RUSAGE" = "xno"; then
     AC_CHECK_HEADER(ctime, , GINAC_ERROR([The standard <ctime> header file could not be found.]))
 fi
 
-AC_CHECK_HEADERS([gmp.h], , AC_MSG_ERROR([This package needs libgmp]))
-
 dnl Check for utilities needed by the different kinds of documentation.
 dnl Documentation needs only be built when extending it, so never mind if it
 dnl cannot find those helpers:

--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,9 @@ AC_PROG_INSTALL
 AM_PROG_LIBTOOL
 AC_LIBTOOL_WIN32_DLL
 
+AC_CHECK_HEADERS([gmp.h], , AC_MSG_ERROR([This package needs gmp headers]))
+AC_SEARCH_LIBS([__gmpz_get_str], [gmp], [], [AC_MSG_ERROR([This package needs libgmp])])
+
 dnl Check for data types which are needed by the hash function 
 dnl (golden_ratio_hash).
 AC_CHECK_SIZEOF(int)

--- a/ginac/Makefile.am
+++ b/ginac/Makefile.am
@@ -19,7 +19,7 @@ libpynac_la_LDFLAGS = -version-info $(LT_VERSION_INFO)
 endif
 libpynac_la_CPPFLAGS = $(PYTHON_CPPFLAGS) -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wno-unused-parameter
 
-libpynac_la_LIBADD = $(PYTHON_LDFLAGS)
+libpynac_la_LIBADD = $(PYTHON_LDFLAGS) $(LIBS)
 ginacincludedir = $(includedir)/pynac
 ginacinclude_HEADERS = ginac.h py_funcs.h add.h archive.h assertion.h basic.h class_info.h \
   clifford.h constant.h infinity.h container.h ex.h expair.h expairseq.h \


### PR DESCRIPTION
The checks for gmp are moved before switching to `CXX` to avoid language problem as gmp is a plain `C` library. I initially selected `mpz_get_str` as one of the functions used by `pynac`, as it happens the real symbol is `__gmpz_get_str` the shorter name being an alias set up in headers.