### PR TITLE
replace is_equal comparions against Infinity and NegInfinity

### DIFF
--- a/ginac/inifcns_trans.cpp
+++ b/ginac/inifcns_trans.cpp
@@ -73,10 +73,11 @@ static ex exp_eval(const ex & x)
 	// exp(-oo) -> 0
 	// exp(UnsignedInfinity) -> error
 	if (x.info(info_flags::infinity)) {
-		if (x.is_equal(Infinity))
-			return Infinity;
-		if (x.is_equal(NegInfinity))
-			return _ex0;
+	        infinity xinf = ex_to<infinity>(x);
+		if (xinf.is_plus_infinity())
+		  return Infinity;
+		if (xinf.is_minus_infinity())
+		  return _ex0;
 		// x is UnsignedInfinity
 		throw (std::runtime_error("exp_eval(): exp^(unsigned_infinity) encountered"));
 	}

--- a/ginac/inifcns_trans.cpp
+++ b/ginac/inifcns_trans.cpp
@@ -75,9 +75,9 @@ static ex exp_eval(const ex & x)
 	if (x.info(info_flags::infinity)) {
 	        infinity xinf = ex_to<infinity>(x);
 		if (xinf.is_plus_infinity())
-		  return Infinity;
+			return Infinity;
 		if (xinf.is_minus_infinity())
-		  return _ex0;
+			return _ex0;
 		// x is UnsignedInfinity
 		throw (std::runtime_error("exp_eval(): exp^(unsigned_infinity) encountered"));
 	}

--- a/ginac/inifcns_trans.cpp
+++ b/ginac/inifcns_trans.cpp
@@ -72,7 +72,7 @@ static ex exp_eval(const ex & x)
 	// exp(oo) -> oo
 	// exp(-oo) -> 0
 	// exp(UnsignedInfinity) -> error
-	if (x.info(info_flags::infinity)) {
+	if (is_exactly_a<infinity>(x)) {
 	        infinity xinf = ex_to<infinity>(x);
 		if (xinf.is_plus_infinity())
 			return Infinity;

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -843,10 +843,11 @@ static ex atan_eval(const ex & x)
 	// arctan(-oo) -> -Pi/2
 	// arctan(UnsignedInfinity) -> error
 	if (x.info(info_flags::infinity)) {
-		if (x.is_equal(Infinity))
-			return _ex1_2*Pi;
-		if (x.is_equal(NegInfinity))
-			return _ex_1_2*Pi;
+	        infinity xinf = ex_to<infinity>(x);
+		if (xinf.is_plus_infinity())
+		        return _ex1_2*Pi;
+		if (xinf.is_minus_infinity())
+		        return _ex_1_2*Pi;
 		// x is UnsignedInfinity
 		throw (std::runtime_error("arctan_eval(): arctan(unsigned_infinity) encountered"));
 	}

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -842,7 +842,7 @@ static ex atan_eval(const ex & x)
 	// arctan(oo) -> Pi/2
 	// arctan(-oo) -> -Pi/2
 	// arctan(UnsignedInfinity) -> error
-	if (x.info(info_flags::infinity)) {
+	if (is_exactly_a<infinity>(x)) {
 	        infinity xinf = ex_to<infinity>(x);
 		if (xinf.is_plus_infinity())
 		        return _ex1_2*Pi;


### PR DESCRIPTION
This is a fix for the problems with the `exp` and `arctan` (same problem occurrs) in #123. 