### PR TITLE
improve evaluation of trigonometric functions

### DIFF
--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -411,8 +411,21 @@ static ex tan_eval(const ex & x)
 		throw (std::runtime_error("tan_eval(): tan(infinity) encountered"));
 	}
 
+	ex coef_pi = x.coeff(Pi).expand();
+	ex rem = _ex0;
+	if (is_exactly_a<add>(coef_pi)){
+		for (size_t i=0; i < coef_pi.nops(); i++){
+			if (coef_pi.op(i).info(info_flags::integer))
+				rem += Pi * coef_pi.op(i);
+		}
+	}
+	else if (coef_pi.info(info_flags::integer))
+		rem = Pi * coef_pi;
+	ex const x_red = x - rem;
+
+
 	// tan(n/d*Pi) -> { all known non-nested radicals }
-	const ex SixtyExOverPi = _ex60*x/Pi;
+	const ex SixtyExOverPi = _ex60*x_red/Pi;
 	ex sign = _ex1;
 	if (is_exactly_a<numeric>(SixtyExOverPi)
                 and SixtyExOverPi.info(info_flags::integer)) {
@@ -459,7 +472,7 @@ static ex tan_eval(const ex & x)
 			return UnsignedInfinity;
 	}
 
-	const ex FortyeightExOverPi = _ex48*x/Pi;
+	const ex FortyeightExOverPi = _ex48*x_red/Pi;
         sign = _ex1;
 	if (is_exactly_a<numeric>(FortyeightExOverPi)
                         and FortyeightExOverPi.info(info_flags::integer)) {
@@ -495,37 +508,32 @@ static ex tan_eval(const ex & x)
 			return sign*(_ex2+sqrt(_ex6)+sqrt(_ex2)+sqrt(_ex3));
 	}
 
-	if (is_exactly_a<function>(x)) {
-		const ex &t = x.op(0);
+	if (is_exactly_a<function>(x_red)) {
+		const ex &t = x_red.op(0);
 
 		// tan(atan(x)) -> x
-		if (is_ex_the_function(x, atan))
+		if (is_ex_the_function(x_red, atan))
 			return t;
 
 		// tan(asin(x)) -> x/sqrt(1+x^2)
-		if (is_ex_the_function(x, asin))
+		if (is_ex_the_function(x_red, asin))
 			return t*power(_ex1-power(t,_ex2),_ex_1_2);
 
 		// tan(acos(x)) -> sqrt(1-x^2)/x
-		if (is_ex_the_function(x, acos))
+		if (is_ex_the_function(x_red, acos))
 			return power(t,_ex_1)*sqrt(_ex1-power(t,_ex2));
 	}
-	
-	// tan(integer*pi) -> 0
-	const ex ExOverPi = x/Pi;
-	if (ExOverPi.info(info_flags::integer))
-		return _ex0;
 
 	// tan(float) -> float
-	if (x.info(info_flags::numeric) && !x.info(info_flags::crational)) {
-		return tan(ex_to<numeric>(x));
+	if (x_red.info(info_flags::numeric) && !x_red.info(info_flags::crational)) {
+		return tan(ex_to<numeric>(x_red));
 	}
 	
 	// tan() is odd
-	if (x.info(info_flags::negative))
-		return -tan(-x);
+	if (x_red.info(info_flags::negative))
+		return -tan(-x_red);
 	
-	return tan(x).hold();
+	return tan(x_red).hold();
 }
 
 static ex tan_deriv(const ex & x, unsigned deriv_param)

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -239,8 +239,20 @@ static ex cos_eval(const ex & x)
 		throw (std::runtime_error("cos_eval(): cos(infinity) encountered"));
 	}
 
+	ex coef_pi = x.coeff(Pi).expand();
+	ex rem = _ex0;
+	if (is_exactly_a<add>(coef_pi)){
+		for (size_t i=0; i < coef_pi.nops(); i++){
+			if ((coef_pi.op(i) / _ex2).info(info_flags::integer))
+				rem += Pi * coef_pi.op(i);
+		}
+	}
+	else if ((coef_pi / _ex2).info(info_flags::integer))
+		rem = Pi * coef_pi;
+	ex const x_red = x - rem;
+
 	// cos(n/d*Pi) -> { all known radicals with nesting depth 2 }
-	const ex SixtyExOverPi = _ex60*x/Pi;
+	const ex SixtyExOverPi = _ex60*x_red/Pi;
 	ex sign = _ex1;
 	if (is_exactly_a<numeric>(SixtyExOverPi)
                 and SixtyExOverPi.info(info_flags::integer)) {
@@ -286,7 +298,7 @@ static ex cos_eval(const ex & x)
 			return _ex0;
 	}
 
-	const ex TwentyforExOverPi = _ex24*x/Pi;
+	const ex TwentyforExOverPi = _ex24*x_red/Pi;
         sign = _ex1;
 	if (is_exactly_a<numeric>(TwentyforExOverPi)
                         and TwentyforExOverPi.info(info_flags::integer)) {
@@ -314,36 +326,36 @@ static ex cos_eval(const ex & x)
 			return sign*(_ex1_4*sqrt(_ex8 - _ex2*sqrt(_ex6) - _ex2*sqrt(_ex2)));
 	}
 
-	if (is_exactly_a<function>(x)) {
-		const ex &t = x.op(0);
+	if (is_exactly_a<function>(x_red)) {
+		const ex &t = x_red.op(0);
 
 		// cos(acos(x)) -> x
-		if (is_ex_the_function(x, acos))
+		if (is_ex_the_function(x_red, acos))
 			return t;
 
 		// cos(asin(x)) -> sqrt(1-x^2)
-		if (is_ex_the_function(x, asin))
+		if (is_ex_the_function(x_red, asin))
 			return sqrt(_ex1-power(t,_ex2));
 
 		// cos(atan(x)) -> 1/sqrt(1+x^2)
-		if (is_ex_the_function(x, atan))
+		if (is_ex_the_function(x_red, atan))
 			return power(_ex1+power(t,_ex2),_ex_1_2);
 	}
 
 	// cos(integer*pi) --> (-1)^integer
-	const ex ExOverPi = x/Pi;
+	const ex ExOverPi = x_red/Pi;
 	if (ExOverPi.info(info_flags::integer))
 		return pow(_ex_1, ExOverPi);
 	
 	// cos(float) -> float
-	if (x.info(info_flags::numeric) && !x.info(info_flags::crational))
-		return cos(ex_to<numeric>(x));
+	if (x_red.info(info_flags::numeric) && !x_red.info(info_flags::crational))
+		return cos(ex_to<numeric>(x_red));
 	
 	// cos() is even
-	if (x.info(info_flags::negative))
-		return cos(-x);
+	if (x_red.info(info_flags::negative))
+		return cos(-x_red);
 	
-	return cos(x).hold();
+	return cos(x_red).hold();
 }
 
 static ex cos_deriv(const ex & x, unsigned deriv_param)

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -64,8 +64,8 @@ static ex sin_eval(const ex & x)
 
 	ex coef_pi = x.coeff(Pi).expand();
 	ex rem = _ex0;
-	if (is_exactly_a<add>(coef_pi)){
-		for (size_t i=0; i < coef_pi.nops(); i++){
+	if (is_exactly_a<add>(coef_pi)) {
+		for (size_t i=0; i < coef_pi.nops(); i++) {
 			if ((coef_pi.op(i) / _ex2).info(info_flags::integer))
 				rem += Pi * coef_pi.op(i);
 		}
@@ -241,8 +241,8 @@ static ex cos_eval(const ex & x)
 
 	ex coef_pi = x.coeff(Pi).expand();
 	ex rem = _ex0;
-	if (is_exactly_a<add>(coef_pi)){
-		for (size_t i=0; i < coef_pi.nops(); i++){
+	if (is_exactly_a<add>(coef_pi)) {
+		for (size_t i=0; i < coef_pi.nops(); i++) {
 			if ((coef_pi.op(i) / _ex2).info(info_flags::integer))
 				rem += Pi * coef_pi.op(i);
 		}
@@ -413,8 +413,8 @@ static ex tan_eval(const ex & x)
 
 	ex coef_pi = x.coeff(Pi).expand();
 	ex rem = _ex0;
-	if (is_exactly_a<add>(coef_pi)){
-		for (size_t i=0; i < coef_pi.nops(); i++){
+	if (is_exactly_a<add>(coef_pi)) {
+		for (size_t i=0; i < coef_pi.nops(); i++) {
 			if (coef_pi.op(i).info(info_flags::integer))
 				rem += Pi * coef_pi.op(i);
 		}

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -176,7 +176,7 @@ static ex sin_eval(const ex & x)
 		return _ex0;
 	
 	// sin(float) -> float
-        if (is_exactly_a<numeric>(x_red) && !x.info(info_flags::crational))
+        if (is_exactly_a<numeric>(x_red) && !x_red.info(info_flags::crational))
 		return sin(ex_to<numeric>(x_red));
 
 	// sin() is odd
@@ -348,7 +348,7 @@ static ex cos_eval(const ex & x)
 		return pow(_ex_1, ExOverPi);
 	
 	// cos(float) -> float
-	if (is_exactly_a<numeric>(x_red) && !x.info(info_flags::crational))
+	if (is_exactly_a<numeric>(x_red) && !x_red.info(info_flags::crational))
 		return cos(ex_to<numeric>(x_red));
 	
 	// cos() is even
@@ -525,7 +525,7 @@ static ex tan_eval(const ex & x)
 	}
 
 	// tan(float) -> float
-	if (is_exactly_a<numeric>(x_red) && !x.info(info_flags::crational)) {
+	if (is_exactly_a<numeric>(x_red) && !x_red.info(info_flags::crational)) {
 		return tan(ex_to<numeric>(x_red));
 	}
 	

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -157,6 +157,11 @@ static ex sin_eval(const ex & x)
 		if (is_ex_the_function(x, atan))
 			return t*power(_ex1+power(t,_ex2),_ex_1_2);
 	}
+
+	// try something
+	const ex ExOverPi = x/Pi;
+	if (ExOverPi.info(info_flags::integer))
+		return _ex0;
 	
 	// sin(float) -> float
         if (x.info(info_flags::numeric) && !x.info(info_flags::crational))
@@ -312,6 +317,11 @@ static ex cos_eval(const ex & x)
 		if (is_ex_the_function(x, atan))
 			return power(_ex1+power(t,_ex2),_ex_1_2);
 	}
+
+	// cos(integer*pi) --> (-1)^integer
+	const ex ExOverPi = x/Pi;
+	if (ExOverPi.info(info_flags::integer))
+		return pow(_ex_1, ExOverPi);
 	
 	// cos(float) -> float
 	if (x.info(info_flags::numeric) && !x.info(info_flags::crational))
@@ -477,6 +487,11 @@ static ex tan_eval(const ex & x)
 			return power(t,_ex_1)*sqrt(_ex1-power(t,_ex2));
 	}
 	
+	// tan(integer*pi) -> 0
+	const ex ExOverPi = x/Pi;
+	if (ExOverPi.info(info_flags::integer))
+		return _ex0;
+
 	// tan(float) -> float
 	if (x.info(info_flags::numeric) && !x.info(info_flags::crational)) {
 		return tan(ex_to<numeric>(x));

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -30,7 +30,7 @@
 #include "operators.h"
 #include "pseries.h"
 #include "utils.h"
-
+#include "add.h"
 
 namespace GiNaC {
 


### PR DESCRIPTION
if possible, the argument passed to the trigonometric functions should be reduced according to the period length. this also enables the evaluation of expression containing assumed integers:

```
sage: var('k', domain='integer')
k
sage: sin(k*pi)
0
sage: cos(2*k*pi + pi/3)
1/2
```
and so on. Related to #130.