### PR TITLE
expand difference before checking flags

### DIFF
--- a/ginac/relational.cpp
+++ b/ginac/relational.cpp
@@ -454,7 +454,7 @@ relational::result relational::decide() const
                         return result::False;
         }
 
-	const ex df = lh-rh;
+	const ex df = (lh-rh).expand();
 //        This will only work when Pynac knows about existing assumptions
 //        if ((not df.info(info_flags::real)) and o!=equal and o!=not_equal)
 //                return result::undecidable;


### PR DESCRIPTION
One of the issues mentioned in [this discussion](https://groups.google.com/forum/#!topic/sage-devel/ojHqBy7oUVU) can be fixed by expanding the difference between the right-hand side and the left-hand side of a relational expression before checking the info flags.