### PR TITLE
simplify trigonometric and hyperbolic functions with argument I*something

### DIFF
--- a/ginac/inifcns_hyperb.cpp
+++ b/ginac/inifcns_hyperb.cpp
@@ -29,6 +29,7 @@
 #include "infinity.h"
 #include "numeric.h"
 #include "mul.h"
+#include "add.h"
 #include "power.h"
 #include "operators.h"
 #include "relational.h"
@@ -49,6 +50,29 @@ namespace GiNaC {
    of "a" at the beginning.   This is for consistency with other
    computer algebra systems.   These print methods are registered
    below with each of the corresponding inverse trig function. */
+
+// helper function: returns whether the expression is a multiple of I
+static bool is_multiple_of_I(const ex & the_ex)
+{
+
+	if (is_exactly_a<numeric>(the_ex)
+	    and the_ex.real_part().is_zero())
+		return true;
+
+	if (is_exactly_a<mul>(the_ex)) {
+		for (size_t i=0; i < the_ex.nops(); ++i)
+			if (is_multiple_of_I(the_ex.op(i)))
+				return true;
+	}
+
+	if (is_exactly_a<add>(the_ex)) {
+		for (size_t i=0; i < the_ex.nops(); ++i)
+			if (!is_multiple_of_I(the_ex.op(i)))
+				return false;
+		return true;
+	}
+	return false;
+};
 
 
 //////////

--- a/ginac/inifcns_hyperb.cpp
+++ b/ginac/inifcns_hyperb.cpp
@@ -112,11 +112,10 @@ static ex sinh_eval(const ex & x)
 			throw (std::runtime_error("sinh_eval(): sinh(unsigned_infinity) encountered"));
 		return x;
 	}
-	
-        ex xoverpi = x/Pi;
-	if (is_exactly_a<numeric>(xoverpi) &&
-		ex_to<numeric>(xoverpi).real().is_zero())  // sinh(I*x) -> I*sin(x)
-		return I*sin(x/I);
+
+	// sinh(I*x) --> I*sin(x/I)
+	if (is_multiple_of_I(x.expand()))
+	    return I*sin(x/I);
 	
 	if (is_exactly_a<function>(x)) {
 		const ex &t = x.op(0);
@@ -207,9 +206,8 @@ static ex cosh_eval(const ex & x)
 		return Infinity;
 	}
 
-        ex xoverpi = x/Pi;
-	if (is_exactly_a<numeric>(xoverpi) &&
-		ex_to<numeric>(xoverpi).real().is_zero())  // cosh(I*x) -> cos(x)
+	// cosh(I*x) --> cos(x)
+	if (is_multiple_of_I(x.expand()))
 		return cos(x/I);
 	
 	if (is_exactly_a<function>(x)) {
@@ -304,9 +302,8 @@ static ex tanh_eval(const ex & x)
 		throw (std::runtime_error("tanh_eval(): tanh(unsigned_infinity) encountered"));
 	}
 		
-        ex xoverpi = x/Pi;
-	if (is_exactly_a<numeric>(xoverpi) &&
-		ex_to<numeric>(xoverpi).real().is_zero())  // tanh(I*x) -> I*tan(x);
+	// tanh(I*x) --> I*tan(x)
+	if (is_multiple_of_I(x.expand()))
 		return I*tan(x/I);
 	
 	if (is_exactly_a<function>(x)) {
@@ -423,21 +420,9 @@ static ex coth_eval(const ex & x)
 		throw (std::runtime_error("coth_eval(): tanh(unsigned_infinity) encountered"));
 	}
 
-        ex xoverpi = x/Pi;
-	if (is_exactly_a<numeric>(xoverpi)) {
-		numeric nxopi = ex_to<numeric>(xoverpi);
-		if (nxopi.real().is_zero()) { // coth(I*x) -> I*cot(x);
-                        numeric xoverpiI = (nxopi*2)/I;
-			if (not xoverpiI.is_integer())
-				return -I*cot(x/I);
-			else if (xoverpiI.is_odd())
-				return _ex0;
-			else
-				return UnsignedInfinity;
-		}
-		else
-			return coth(x).hold();
-	}
+	// coth(I*x) --> -I*cot(x)
+	if (is_multiple_of_I(x.expand()))
+		return -I*cot(x/I);
 
 	if (is_exactly_a<function>(x)) {
 		const ex &t = x.op(0);
@@ -539,10 +524,9 @@ static ex sech_eval(const ex & x)
 			return sech(-x);
 	}
 
-        ex xoverpi = x/Pi;
-	if (is_exactly_a<numeric>(xoverpi) &&
-		ex_to<numeric>(xoverpi).real().is_zero())
-		return sec(x/I);
+	// sech(x*I) --> sec(x)
+	if (is_multiple_of_I(x.expand()))
+	    return sec(x/I);
 
 	// sech(oo) -> 0
 	// sech(-oo) -> 0
@@ -654,9 +638,8 @@ static ex csch_eval(const ex & x)
 			return -csch(-x);
 	}
 
-        ex xoverpi = x/Pi;
-	if (is_exactly_a<numeric>(xoverpi) &&
-		ex_to<numeric>(xoverpi).real().is_zero())
+	// csch(I*x) --> -I*csc(x)
+	if (is_multiple_of_I(x.expand()))
 		return -I*csc(x/I);
 
 	// csch(oo) -> 0

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -640,6 +640,9 @@ static ex tan_eval(const ex & x)
         else
                 x_red = x;
 
+	if (is_multiple_of_I(x_red.expand()))
+		return I*tanh(x_red/I);
+
 	if (is_exactly_a<function>(x_red)) {
 		const ex &t = x_red.op(0);
 
@@ -761,6 +764,9 @@ static ex cot_eval(const ex & x)
 		throw (std::runtime_error("cotan_eval(): cot(0) encountered"));
 	}
 
+	if (is_multiple_of_I(x.expand()))
+		return -I*coth(x/I);
+
 	if (is_exactly_a<function>(x)) {
 		const ex &t = x.op(0);
                    
@@ -875,6 +881,9 @@ static ex sec_evalf(const ex & x, PyObject* parent)
 
 static ex sec_eval(const ex & x)
 {
+	if (is_multiple_of_I(x.expand()))
+		return sech(x/I);
+
 	if (is_exactly_a<function>(x)) {
 		const ex &t = x.op(0);
 
@@ -994,6 +1003,9 @@ static ex csc_eval(const ex & x)
 	if (x.is_zero()) {
 		throw (std::runtime_error("csc_eval(): csc(0) encountered"));
 	}
+
+	if (is_multiple_of_I(x.expand()))
+		return -I*csch(x/I);
 
 	if (is_exactly_a<function>(x)) {
 		const ex &t = x.op(0);

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -204,6 +204,10 @@ static ex sin_eval(const ex & x)
         else
                 x_red = x;
 
+	// simplify sin(I*x) --> I*sinh(x)
+	if (is_multiple_of_I(x_red.expand()))
+		return I*sinh(x_red/I);
+
 	if (is_exactly_a<function>(x_red)) {
 		const ex &t = x_red.op(0);
 
@@ -414,6 +418,10 @@ static ex cos_eval(const ex & x)
 	}
         else
                 x_red = x;
+
+	// simplify cos(I*x) --> cosh(x)
+	if (is_multiple_of_I(x_red.expand()))
+		return cosh(x_red/I);
 
 	if (is_exactly_a<function>(x_red)) {
 		const ex &t = x_red.op(0);

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -41,6 +41,30 @@ namespace GiNaC {
    below with each of the corresponding inverse trig function. */
 
 
+// helper function: returns whether the expression is a multiple of I
+static bool is_multiple_of_I(const ex & the_ex)
+{
+
+	if (is_exactly_a<numeric>(the_ex)
+	    and the_ex.real_part().is_zero())
+		return true;
+
+	if (is_exactly_a<mul>(the_ex)) {
+		for (size_t i=0; i < the_ex.nops(); ++i)
+			if (is_multiple_of_I(the_ex.op(i)))
+				return true;
+	}
+
+	if (is_exactly_a<add>(the_ex)) {
+		for (size_t i=0; i < the_ex.nops(); ++i)
+			if (!is_multiple_of_I(the_ex.op(i)))
+				return false;
+		return true;
+	}
+	return false;
+};
+
+
 //////////
 // sine (trigonometric function)
 //////////


### PR DESCRIPTION
The code here currently implements the simplifications `sin(I*something) --> I*sinh(something)` and `cos(I*something) --> cosh(something)`.

Performance probably is a bit worse (a call to `real_part` is needed, which is python/cython).

This should only be considered mergeable after the following TODOs are done:
- [x] Simplifications for all trigonometric functions #155
- [x] Simplifications for all hyperbolic functions #159 
- [x] Check for performance issues
