### PR TITLE
return UnsignedInfinity at poles of trigonometric functions

### DIFF
--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -722,11 +722,12 @@ static ex cot_evalf(const ex & x, PyObject* parent)
 
 static ex cot_eval(const ex & x)
 {
-	// cot(0) -> error
-	// This should be before the tests below, since multiplying infinity
-	// with other values raises runtime_errors
-	if (x.is_zero()) {
-		throw (std::runtime_error("cotan_eval(): cot(0) encountered"));
+	// cot(k*pi) -> Infinity
+	ex exoverpi = x/Pi;
+	if (is_exactly_a<numeric>(exoverpi)) {
+		if (ex_to<numeric>(exoverpi).is_integer()) {
+			return UnsignedInfinity;
+		}
 	}
 
 	if (is_exactly_a<function>(x)) {
@@ -956,11 +957,12 @@ static ex csc_evalf(const ex & x, PyObject* parent)
 
 static ex csc_eval(const ex & x)
 {
-	// csc(0) -> error
-	// This should be before the tests below, since multiplying infinity
-	// with other values raises runtime_errors
-	if (x.is_zero()) {
-		throw (std::runtime_error("csc_eval(): csc(0) encountered"));
+	// csc(k*pi) -> Infinity
+	ex exoverpi = x/Pi;
+	if (is_exactly_a<numeric>(exoverpi)) {
+		if (ex_to<numeric>(exoverpi).is_integer()) {
+			return UnsignedInfinity;
+		}
 	}
 
 	if (is_exactly_a<function>(x)) {

--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -722,14 +722,6 @@ static ex cot_evalf(const ex & x, PyObject* parent)
 
 static ex cot_eval(const ex & x)
 {
-	// cot(k*pi) -> Infinity
-	ex exoverpi = x/Pi;
-	if (is_exactly_a<numeric>(exoverpi)) {
-		if (ex_to<numeric>(exoverpi).is_integer()) {
-			return UnsignedInfinity;
-		}
-	}
-
 	if (is_exactly_a<function>(x)) {
 		const ex &t = x.op(0);
                    
@@ -770,8 +762,12 @@ static ex cot_eval(const ex & x)
 	}
 
         ex res = tan_eval(x);
-	if (not is_ex_the_function(res, tan))
-                return power(res, _ex_1);
+	if (not is_ex_the_function(res, tan)) {
+		if (not res.is_zero())
+			return power(res, _ex_1);
+		else
+			return UnsignedInfinity;
+	}
 
 	return cot(x).hold();
 }
@@ -957,14 +953,6 @@ static ex csc_evalf(const ex & x, PyObject* parent)
 
 static ex csc_eval(const ex & x)
 {
-	// csc(k*pi) -> Infinity
-	ex exoverpi = x/Pi;
-	if (is_exactly_a<numeric>(exoverpi)) {
-		if (ex_to<numeric>(exoverpi).is_integer()) {
-			return UnsignedInfinity;
-		}
-	}
-
 	if (is_exactly_a<function>(x)) {
 		const ex &t = x.op(0);
 


### PR DESCRIPTION
This fixes the inconsistent behavior of `cot(0)`. Also fixes the doctest failures caused by the rewriting of #162.