### PR TITLE
clean up header

### DIFF
--- a/ginac/container.h
+++ b/ginac/container.h
@@ -34,7 +34,7 @@
 #include <vector>
 #include <list>
 #include <memory>
-#include <bits/algorithmfwd.h>
+#include <algorithm>
 
 namespace GiNaC {
 


### PR DESCRIPTION
You should not use `/bits/algorithmfwd.h` in `ginac/container.h`. This is an internal header, see https://gcc.gnu.org/onlinedocs/gcc-4.6.2/libstdc++/api/a00749.html in particular at the very bottom:
```
This is an internal header file, included by other library headers. Do not attempt to use it directly. Instead, include <algorithm>.
```
I spotted this trying to compile `pynac` with clang on OS X.