### PR TITLE
Update cot(float) to use inverse of tan()

### DIFF
--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -774,7 +774,7 @@ static ex cot_eval(const ex & x)
 
 	// cot(float) -> float
 	if (is_exactly_a<numeric>(x) && !x.info(info_flags::crational)) {
-		return tan_evalf(Pi.evalf()/2-ex_to<numeric>(x), nullptr);
+		return tan(ex_to<numeric>(x)).inverse();
 	}
 
         ex res = tan_eval(x);


### PR DESCRIPTION
This change fixes Trac [21365](https://trac.sagemath.org/ticket/21365).

You'll know better than I if it creates other unexpected problems. Is there a reason cot() was being treated differently from sec() and csc() for floats?