### PR TITLE
Support gegenbauer(n,a,x) with negative 'a'

### DIFF
--- a/ginac/inifcns_orthopoly.cpp
+++ b/ginac/inifcns_orthopoly.cpp
@@ -109,6 +109,8 @@ static ex gegenb_evalf(const ex& n, const ex &a, const ex& x, PyObject* parent)
 
 static ex gegenb_eval(const ex& n, const ex &a, const ex& x)
 {
+	numeric numa = 1;
+
 	if (is_exactly_a<numeric>(x)) {
                 numeric numx = ex_to<numeric>(x);
                 if (is_exactly_a<numeric>(n)
@@ -129,7 +131,13 @@ static ex gegenb_eval(const ex& n, const ex &a, const ex& x)
 	if (numn.is_equal(*_num1_p))
 		return _ex2 * a * x;
 
-	if (not is_exactly_a<numeric>(a)) {
+	if (is_exactly_a<numeric>(a)) {
+		numa = ex_to<numeric>(a);
+		if (numa.is_zero())
+			return _ex0; // C_n^0(x) = 0
+	}
+
+	if (not is_exactly_a<numeric>(a) or numa < 0) {
 		ex p = _ex1;
 		ex sum = _ex0;
 		ex sign = _ex1;
@@ -154,10 +162,6 @@ static ex gegenb_eval(const ex& n, const ex &a, const ex& x)
 		}
 		return sum;
 	}
-
-        numeric numa = ex_to<numeric>(a);
-        if (not numa.info(info_flags::rational) or numa < 0)
-                throw std::runtime_error("gegenb_eval: The parameter a must be a nonnegative rational");
 
 	// from here on see flint2/fmpq_poly/gegenbauer_c.c
 	numeric numer = numa.numer();


### PR DESCRIPTION
There is nothing special about negative values of 'a'.

sage: gegenbauer(2,a,x)
2*(a + 1)*a*x^2 - a
sage: gegenbauer(2,-3,x)
12*x^2 + 3
sage: gegenbauer(120,-99/2,3)
1654502372608570682112687530178328494861923493372493824

Note that this patch also removes the requirement for 'a'
to be integer (when it is positive):

sage: gegenbauer(5,9/2,x)
21879/8*x^5 - 6435/4*x^3 + 1287/8*x
sage: gegenbauer(15,3/2,5)
3903412392243800

All these cases were checked with the results from Mathematica.

Signed-off-by: Carlos R. Mafra <crmafra@gmail.com>