### PR TITLE
fix the incorrectly implemented formula for expansion around 1

### DIFF
--- a/ginac/inifcns_zeta.cpp
+++ b/ginac/inifcns_zeta.cpp
@@ -174,8 +174,8 @@ static ex zeta1_series(const ex& m, const relational& rel, int order, unsigned o
 	ex ser = 1/(m-1);
 	numeric fac = 1;
 	for (int n = 0; n <= order; ++n) {
-	  fac = fac.mul(n+1);
 	  ser += pow(-1, n) * stieltjes(n) * pow(m-1, n) * fac.inverse();
+	  fac = fac.mul(n+1);
 	}
 	return ser.series(rel, order, options);
 }


### PR DESCRIPTION
When comparing the formula in https://en.wikipedia.org/wiki/Stieltjes_constants and the sage-output
```
sage: zeta(s).series(s==1, 2)
1*(s - 1)^(-1) + (euler_gamma) + (-1/2*stieltjes(1))*(s - 1) + Order((s - 1)^2)
```
we find that the formula in pynac is implemented incorrectly, as we divide by `(n+1)!` instead of `n!`. This is fixed within this PR.