### PR TITLE
Switch factory detection to using pkg-config and flint to pynac.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,8 +151,13 @@ if test "x$CONFIG_RUSAGE" = "xno"; then
     AC_CHECK_HEADER(ctime, , GINAC_ERROR([The standard <ctime> header file could not be found.]))
 fi
 
-AC_CHECK_HEADERS([factory/factory.h], , AC_MSG_ERROR([This package needs Singular-factory headers]))
-AC_SEARCH_LIBS([_Z17setCharacteristici], [factory], [], [AC_MSG_ERROR([This package needs libfactory])])
+PKG_PROG_PKG_CONFIG
+
+dnl Find Singular's factory header and library with pkg-config
+PKG_CHECK_MODULES([FACTORY], [factory],[
+    AC_SUBST(FACTORY_CFLAGS)
+    AC_SUBST(FACTORY_LIBS)],
+    [AC_MSG_ERROR([This package needs libfactory]))
 
 dnl Check for utilities needed by the different kinds of documentation.
 dnl Documentation needs only be built when extending it, so never mind if it

--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ dnl Find Singular's factory header and library with pkg-config
 PKG_CHECK_MODULES([FACTORY], [factory],[
     AC_SUBST(FACTORY_CFLAGS)
     AC_SUBST(FACTORY_LIBS)],
-    [AC_MSG_ERROR([This package needs libfactory]))
+    [AC_MSG_ERROR([This package needs libfactory])])
 
 dnl Check for utilities needed by the different kinds of documentation.
 dnl Documentation needs only be built when extending it, so never mind if it

--- a/ginac/Makefile.am
+++ b/ginac/Makefile.am
@@ -20,9 +20,9 @@ libpynac_la_LDFLAGS = -version-info $(LT_VERSION_INFO) -no-undefined
 else
 libpynac_la_LDFLAGS = -version-info $(LT_VERSION_INFO)
 endif
-libpynac_la_CPPFLAGS = $(PYTHON_CPPFLAGS) -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wno-unused-parameter
+libpynac_la_CPPFLAGS = $(PYTHON_CPPFLAGS) @FACTORY_CFLAGS@ -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wno-unused-parameter
 
-libpynac_la_LIBADD = $(PYTHON_LDFLAGS) $(LIBS) $(LIBGIAC)
+libpynac_la_LIBADD = $(PYTHON_LDFLAGS) $(LIBS) @FACTORY_LIBS@ $(LIBGIAC)
 ginacincludedir = $(includedir)/pynac
 ginacinclude_HEADERS = ginac.h py_funcs.h add.h archive.h assertion.h basic.h class_info.h \
   clifford.h constant.h infinity.h container.h ex.h expair.h expairseq.h \

--- a/pynac.pc.in
+++ b/pynac.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: pynac
 Description: C++/Python library for symbolic calculations
 Version: @VERSION@
-Requires: python-@PYTHON_VERSION@
-Libs: -L${libdir} -lpynac -lgmp
+Requires: python-@PYTHON_VERSION@ factory
+Libs: -L${libdir} -lpynac -flint -lgmp
 Cflags: -I${includedir}

--- a/pynac.pc.in
+++ b/pynac.pc.in
@@ -7,5 +7,5 @@ Name: pynac
 Description: C++/Python library for symbolic calculations
 Version: @VERSION@
 Requires: python-@PYTHON_VERSION@ factory
-Libs: -L${libdir} -lpynac -flint -lgmp
+Libs: -L${libdir} -lpynac -lflint -lgmp
 Cflags: -I${includedir}


### PR DESCRIPTION
This branch uses `pkg-config` to find factory's include files and library. Since singular a `factory.pc` file is installed. While factory will likely bring `-lflint` I still added it to `pynac.pc.in` in case `factory` stop requiring it.

You may need development version of the `pkg-config` package to get `pkg.m4` which is needed to produce a correct `configure`. 