### PR TITLE
Add libgiac to pynac.pc

### DIFF
--- a/pynac.pc.in
+++ b/pynac.pc.in
@@ -7,5 +7,5 @@ Name: pynac
 Description: C++/Python library for symbolic calculations
 Version: @VERSION@
 Requires: python-@PYTHON_VERSION@ factory
-Libs: -L${libdir} -lpynac -lflint -lgmp
+Libs: -L${libdir} -lpynac @LIBGIAC@ -lflint -lgmp
 Cflags: -I${includedir}


### PR DESCRIPTION
If we link to giac, it should go in pynac.pc too.