### PR TITLE
Add a macro for compatibility to python3 in inifcns_hyperg.cpp

### DIFF
--- a/ginac/inifcns_hyperg.cpp
+++ b/ginac/inifcns_hyperg.cpp
@@ -43,6 +43,10 @@
 #include <string>
 #include <memory>
 
+#if PY_MAJOR_VERSION > 2
+#define PyString_FromString PyBytes_FromString
+#endif
+
 namespace GiNaC {
 
 inline void py_error(const char* errmsg) {


### PR DESCRIPTION
I based the replacement to the one done in numeric.cpp.