### PR TITLE
Some fixes to handling Python 3 long types

### DIFF
--- a/ginac/numeric.cpp
+++ b/ginac/numeric.cpp
@@ -50,6 +50,7 @@
  */
 
 #include <Python.h>
+#include <longintrepr.h>
 #include "flint/fmpz.h"
 #include "flint/fmpz_factor.h"
 


### PR DESCRIPTION
Removed the `PyInt_` macro definitions on Python 3, since that only invites
errors (e.g. assuming that a PyLong object can be converted without overflow
to a C long).