### PR TITLE
Fix TypeError on Python 3

### DIFF
--- a/ginac/numeric.cpp
+++ b/ginac/numeric.cpp
@@ -178,8 +178,7 @@ inline void py_error(const char* errmsg) {
 #define PyNumber_TrueDivide PyNumber_Divide
 
 #else
-#define PyString_FromString PyBytes_FromString
-#define PyString_AsString PyBytes_AsString
+#define PyString_FromString PyUnicode_FromString
 #endif
 
 // The following variable gets changed to true once


### PR DESCRIPTION
This should use `PyUnicode_FromString` on Python 3, and `PyString_AsString` isn't used at all in this module.  This fixes numerous bugs in Sage on Python 3 like:

```
sage: arcsinh(z)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-fbfc0c968329> in <module>()
----> 1 arcsinh(z)

/home/embray/src/sagemath/sage-python3/local/lib/python3.6/site-packages/sage/symbolic/function.pyx in sage.symbolic.function.BuiltinFunction.__call__ (build/cythonized/sage/symbolic/function.cpp:11719)()
    988
    989             if callable(method):
--> 990                 res = method()
    991
    992         if res is None:

/home/embray/src/sagemath/sage-python3/local/lib/python3.6/site-packages/sage/symbolic/expression.pyx in sage.symbolic.expression.Expression.arcsinh (build/cythonized/sage/symbolic/expression.cpp:49022)()
   8588         """
   8589         return new_Expression_from_GEx(self._parent,
-> 8590                 g_hold_wrapper(g_asinh, self._gobj, hold))
   8591
   8592     def arccosh(self, hold=False):

TypeError: attribute name must be string, not 'bytes'
```