### PR TITLE
fix numeric::ratlog in the case where the argument is an MPZ type but the base is a LONG type

### DIFF
--- a/ginac/numeric.cpp
+++ b/ginac/numeric.cpp
@@ -3758,7 +3758,7 @@ const numeric numeric::ratlog(const numeric &b, bool& israt) const {
                 return c;
         }
         if (b.t == LONG)
-                return ratlog(to_bigint(), israt);
+                return ratlog(b.to_bigint(), israt);
         if (t == LONG)
                 return to_bigint().ratlog(b, israt);
         if (t == MPZ and b.t == MPZ) {


### PR DESCRIPTION
See https://trac.sagemath.org/ticket/25979