### PR TITLE
Fix compliation error with GMP long long limbs.

### DIFF
--- a/ginac/useries.cpp
+++ b/ginac/useries.cpp
@@ -82,10 +82,10 @@ long fmpq_poly_ldegree(const fmpq_poly_t& fp)
         if (fmpq_poly_is_zero(fp))
                 return 0;
         long len = fmpq_poly_length(fp);
-        for (slong n=0; n<=len; n++) {
+        for (long n=0; n<=len; n++) {
                 fmpq_t c;
                 fmpq_init(c);
-                fmpq_poly_get_coeff_fmpq(c, fp, n);
+                fmpq_poly_get_coeff_fmpq(c, fp, (slong)n);
                 if (not fmpq_is_zero(c)) {
                         fmpq_clear(c);
                         return n;
@@ -435,12 +435,12 @@ ex useries(const ex& the_ex, const symbol& x, int order, unsigned options)
         }
 
         // Fill expair vector
-        for (slong n=0; n<=deg+prec; n++) {
+        for (int n=0; n<=deg+prec; n++) {
                 if (n + fp.offset >= order)
                         break;
                 fmpq_t c;
                 fmpq_init(c);
-                fmpq_poly_get_coeff_fmpq(c, fp.ft, n);
+                fmpq_poly_get_coeff_fmpq(c, fp.ft, (slong)n);
                 if (not fmpq_is_zero(c)) {
                         mpq_t gc;
                         mpq_init(gc);


### PR DESCRIPTION
Depending how GMP is configured the macro from flint, `slong`, which actually
refers to GMP's `mp_limb_signed_t`, may be a `long long` instead of plain `long`.

`numeric` doesn't have a constructor for `long long`, leading to an ambiguous
overload error on the constructor.  In this case it should make more sense
to just use normal int and long types for these loop variables as it
makes sense to, and only cast to the "slong" type when passing to the
flint interface.