### PR TITLE
Allow "configure --disable-maintainer-mode"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,8 @@ AC_CONFIG_SRCDIR(ginac/basic.cpp)
 AC_CONFIG_HEADERS(config.h)
 dnl This defines PACKAGE and VERSION.
 AM_INIT_AUTOMAKE([gnu 1.7 dist-bzip2])
+# Allow "configure --disable-maintainer-mode" to disable timestamp checking 
+AM_MAINTAINER_MODE([enable])
 
 AM_PATH_PYTHON([2.7])
 dnl AM_PATH_PYTHON([3.4.1])


### PR DESCRIPTION
Allow "configure --disable-maintainer-mode" to disable timestamp checking. Useful for building on clusters and other interesting platforms, in particular as a part of Sage.