### PR TITLE
fix sign error in cot_imag_part

### DIFF
--- a/ginac/inifcns_trig.cpp
+++ b/ginac/inifcns_trig.cpp
@@ -839,7 +839,7 @@ static ex cot_imag_part(const ex & x)
 {
 	ex a = GiNaC::real_part(mul(x, _ex2));
 	ex b = GiNaC::imag_part(mul(x, _ex2));
-	return sinh(b)/(cosh(b) - cos(a));
+	return -sinh(b)/(cosh(b) - cos(a));
 }
 
 static ex cot_series(const ex &x,


### PR DESCRIPTION
My complex analysis students found a sign error for the (symbolic) imaginary part of the cotangent.

The correct formula can be found [in the digital library of mathematical functions](https://dlmf.nist.gov/4.21#E40), where the imaginary part is given as

```math
\Im(\cot(z)) = \frac{- \sinh(2y)}{cosh(2y) - cos(2x)}.
```