### PR TITLE
define PY_SSIZE_T_CLEAN

### DIFF
--- a/ginac/function.cpp
+++ b/ginac/function.cpp
@@ -21,6 +21,7 @@
  */
 
 #define register
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "py_funcs.h"
 #include "function.h"

--- a/ginac/numeric.cpp
+++ b/ginac/numeric.cpp
@@ -50,6 +50,7 @@
  */
 
 #define register
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <longintrepr.h>
 #include "flint/fmpz.h"


### PR DESCRIPTION
This is required to fix deprecation warnings on unpickling with Python 3.8:
DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats