### PR TITLE
Actually check if result of division fits in long instead of in int

### DIFF
--- a/ginac/numeric.cpp
+++ b/ginac/numeric.cpp
@@ -3241,8 +3241,8 @@ long numeric::to_long() const {
                 mpz_init(bigint);
                 mpz_fdiv_q(bigint, mpq_numref(v._bigrat),
                                 mpq_denref(v._bigrat));
-                if (mpz_fits_sint_p(v._bigint)) {
-                        long n = mpz_get_si(bigint);
+                if (mpz_fits_slong_p(v._bigint)) {
+                        long n = (long int)mpz_get_si(bigint);
                         mpz_clear(bigint);
                         return n;
                 }

--- a/ginac/numeric.cpp
+++ b/ginac/numeric.cpp
@@ -3242,7 +3242,7 @@ long numeric::to_long() const {
                 mpz_fdiv_q(bigint, mpq_numref(v._bigrat),
                                 mpq_denref(v._bigrat));
                 if (mpz_fits_slong_p(v._bigint)) {
-                        long n = (long int)mpz_get_si(bigint);
+                        long n = mpz_get_si(bigint);
                         mpz_clear(bigint);
                         return n;
                 }


### PR DESCRIPTION
As outlined in #356 and [Sage Trac #29156](https://trac.sagemath.org/ticket/29156), there is an issue with exponentiation where the exponent is negative and the numerator is greater than 32 bits. I just changed the function which throws an error if the numerator is greater than 32 bits to only do so when the numerator is greater than 64 bits (well, unless you've got some crazy old 32-bit system). Maybe this isn't the right fix, but it's at least doing more of what the method `numeric::to_long` is advertising. Here is a diff for a doctest addition:

[diff.txt](https://github.com/pynac/pynac/files/5398434/diff.txt)
