### PR TITLE
Remove Py_INCREF in numeric.cpp

### DIFF
--- a/ginac/numeric.cpp
+++ b/ginac/numeric.cpp
@@ -767,7 +767,6 @@ numeric::numeric(const numeric& other) : basic(&numeric::tinfo_static) {
                 return;
         case PYOBJECT:
                 v = other.v;
-                Py_INCREF(v._pyobject);
                 return;
         case MPZ:
                 mpz_init(v._bigint);


### PR DESCRIPTION
Comment 6 in the discussion on Sage Trac ticket 27536
suggests this might fix the memleak reported at #359.