### PR TITLE
Correctly print python 3.10 version string

### DIFF
--- a/m4/ax_python_devel.m4
+++ b/m4/ax_python_devel.m4
@@ -190,7 +190,7 @@ EOD`
 				ac_python_version=$PYTHON_VERSION
 			else
 				ac_python_version=`$PYTHON -c "import sys; \
-					print (sys.version[[:3]])"`
+					print (sys.version_info[[0]], '.', sys.version_info[[1]], sep='')"`
 			fi
 		fi
 


### PR DESCRIPTION
When python 3.10 is released, `sys.version[:3]` will yield '3.1', not '3.10'.