### PR TITLE
Add appropriate header for gcc11

### DIFF
--- a/ginac/numeric.h
+++ b/ginac/numeric.h
@@ -51,6 +51,7 @@
 #include "ex.h"
 
 #include <gmp.h>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 #include <iostream>


### PR DESCRIPTION
pynac doesn't currently compile with gcc-11 because of some changes in header handling. This PR adds one such header that now needs to be explicitly added.
The change should be compatible with other compilers, including older version of gcc.