### PR TITLE
31585overflow32bit

### DIFF
--- a/ginac/numeric.cpp
+++ b/ginac/numeric.cpp
@@ -2411,6 +2411,10 @@ numeric & operator/=(numeric & lh, const numeric & rh)
         }
         switch (lh.t) {
         case LONG: {
+                if (rh.v._long == -1) { // use multiplication to avoid possible overflow
+                        lh *= -1;
+                        return lh;
+                }
                 auto ld = std::div(lh.v._long, rh.v._long);
                 if (ld.rem == 0) {
                         lh.v._long = ld.quot;


### PR DESCRIPTION
This is the pynac patch of trac ticket [#31585](https://trac.sagemath.org/ticket/31585) that fixes an overflow error in multiplication, division, and absolute value when working with long integers. The errors currently arise only on 32-bit machines, but that may change in the future (see trac ticket [#31986](https://trac.sagemath.org/ticket/31986)). Doctests are in the trac PR.
